### PR TITLE
Adiciona a funcionalidade de atualização da quantidade de itens.

### DIFF
--- a/MeatlessApp/Screens/Detail/MenuCellView.swift
+++ b/MeatlessApp/Screens/Detail/MenuCellView.swift
@@ -1,7 +1,5 @@
 import UIKit
 
-// STORY 5: Implement minusButton and plusButton actions. Whenever they're pressed, quantityLabel must be updated accordingly.
-
 class MenuCellView: UITableViewCell {
     
    private var mainStackView: UIStackView = {
@@ -108,15 +106,17 @@ private extension MenuCellView {
         
         configureSubviews()
         configureSubviewsConstraints()
+        minusButton.addTarget(self, action: #selector(minusButtonTapped), for: .touchUpInside)
+        plusButton.addTarget(self, action: #selector(plusButtonTapped), for: .touchUpInside)
     }
-
+    
     func configureSubviews() {
-
+        
         contentView.addSubview(mainStackView)
         mainStackView.addArrangedSubview(itemImageView)
         mainStackView.addArrangedSubview(labelsStackView)
         mainStackView.addArrangedSubview(buttonsStackView)
-
+        
         labelsStackView.addArrangedSubview(itemNameLabel)
         labelsStackView.addArrangedSubview(itemPriceLabel)
         
@@ -124,21 +124,35 @@ private extension MenuCellView {
         buttonsStackView.addArrangedSubview(quantityLabel)
         buttonsStackView.addArrangedSubview(plusButton)
     }
-
+    
     func configureSubviewsConstraints() {
-
+        
         NSLayoutConstraint.activate([
             mainStackView.topAnchor.constraint(equalTo: topAnchor),
             mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
             mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor,  constant: -16),
-
+            
             itemImageView.widthAnchor.constraint(equalToConstant: 64),
             itemImageView.heightAnchor.constraint(equalToConstant: 64),
-
+            
             labelsStackView.leadingAnchor.constraint(equalTo: itemImageView.trailingAnchor, constant: 16),
             labelsStackView.topAnchor.constraint(equalTo: mainStackView.topAnchor, constant: 16),
             labelsStackView.bottomAnchor.constraint(equalTo: mainStackView.bottomAnchor, constant: -16)
         ])
+    }
+    
+    @objc func minusButtonTapped() {
+        if let currentQuantity = Int(quantityLabel.text ?? "0"), currentQuantity > 0 {
+            let newQuantity = currentQuantity - 1
+            quantityLabel.text = "\(newQuantity)"
+        }
+    }
+    
+    @objc func plusButtonTapped() {
+        if let currentQuantity = Int(quantityLabel.text ?? "0"), currentQuantity < 99 {
+            let newQuantity = currentQuantity + 1
+            quantityLabel.text = "\(newQuantity)"
+        }
     }
 }


### PR DESCRIPTION
Adiciona a funcionalidade de atualização da quantidade de itens no `MenuCellView`. Agora, os botões "+" e "-" permitem ao usuário aumentar ou diminuir a quantidade de itens, respeitando os limites de 0 e 99.

Impede que o botão "-" diminua a quantidade quando esta já estiver em "0". 
Impede que o botão "+" aumente a quantidade além de "99".

- A label `quantityLabel` é atualizada em tempo real quando os botões são pressionados.
 
## Checklist before requesting a review

Put an "X" in the boxes that apply.

- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] Does not contain commented code

## Screenshots 
![simulator_screenshot_CD1DD801-6CB5-43A4-B289-C204A7FE743F](https://github.com/evercodeinc/project-meatless-ios-anap1082-38cb0e6246/assets/93355133/5edc6b60-f133-4329-8786-15d8a53e859d)

 

